### PR TITLE
add uv to propagatedBuildInputs

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -26,7 +26,7 @@
           format = "pyproject";
           src = ./.;
           nativeBuildInputs = [pkgs.python312Packages.hatchling];
-          propagatedBuildInputs = with pkgs.python312Packages; [rich packaging toml urllib3 networkx];
+          propagatedBuildInputs = with pkgs.python312Packages; [uv rich packaging toml urllib3 networkx];
         };
       }
     );


### PR DESCRIPTION
uv was missing from the packaging, causing `nix run` to fail.

The devShell is using `pkgs.uv` while the package is using `pkgs.python312Packages.uv`, I don't know which is more appropriate. 