### PR TITLE
Add packages for missing libcusparseLt.so.0 and libcufile.so.0

### DIFF
--- a/src/uv2nix_hammer/rules.py
+++ b/src/uv2nix_hammer/rules.py
@@ -514,7 +514,7 @@ class BuildInputs(Rule):
             ("libcublas.so.11 -> not found!", "cudaPackages_11.libcublas"),
             ("libcusparse.so.12 -> not found!", "cudaPackages.libcusparse"),
             ("libcusparse.so.11 -> not found!", "cudaPackages_11.libcusparse"),
-            ("libcusparseLt.so.0 -> not found!", "cudaPackages.libcusparselt"),
+            ("libcusparseLt.so.0 -> not found!", "cudaPackages.cusparselt"),
             ("libcufile.so.0 -> not found!", "cudaPackages.libcufile"),
             ("libcusolver.so.11 -> not found!", "cudaPackages.libcusolver"),
             (


### PR DESCRIPTION
Hello! I can't believe this is just the second PR for this repository

I recently ran into version 2.7.1 of Torch, and it required these two additional packages to build. So I wanted to add them upstream with their corresponding packages.