### PR TITLE
fix regex for detecting build failures in load_failures function in newer nix

### DIFF
--- a/src/uv2nix_hammer/__init__.py
+++ b/src/uv2nix_hammer/__init__.py
@@ -319,7 +319,7 @@ def get_nix_log(drv):
 def load_failures(project_folder, run_no):
     log_file = project_folder / f"run_{run_no}.log"
     raw = log_file.read_text()
-    failed_drvs = re.findall("error: builder for '(/nix/store/[^']+)' failed", raw)
+    failed_drvs = re.findall("error: (?:builder for|Cannot build) '(/nix/store/[^']+)'(?:\\.| failed)", raw)
     return {drv: get_nix_log(drv) for drv in failed_drvs if not "test-venv" in drv}
 
 


### PR DESCRIPTION
See https://github.com/NixOS/nix/blob/dbc235cc62b0f26d459c1df7b4659ff15abdc718/src/libstore/build/derivation-building-goal.cc#L202 for the new error message format